### PR TITLE
Invokable service callbacks.

### DIFF
--- a/Callback/ContainerAwareCallback.php
+++ b/Callback/ContainerAwareCallback.php
@@ -41,7 +41,13 @@ class ContainerAwareCallback extends Callback
             && 0 === strpos($this->callable[0], '@')
             && $this->container->has($serviceId = substr($this->callable[0], 1))
         ) {
-            $this->callable[0] = $this->container->get($serviceId);
+            $service = $this->container->get($serviceId);
+
+            if (is_callable($service)) {
+                $this->callable = $service;
+            } else {
+                $this->callable[0] = $service;
+            }
         }
 
         return parent::call($event);

--- a/spec/winzou/Bundle/StateMachineBundle/Callback/ContainerAwareCallbackSpec.php
+++ b/spec/winzou/Bundle/StateMachineBundle/Callback/ContainerAwareCallbackSpec.php
@@ -31,11 +31,6 @@ class ContainerAwareCallbackSpec extends ObjectBehavior
         $this->call($event)->shouldReturn(true);
     }
 
-    function dummy()
-    {
-        return true;
-    }
-
     function it_does_not_convert_object($container, TransitionEvent $event, ContainerAwareCallbackSpec $service)
     {
         $this->beConstructedWith(array(), array($service, 'dummy'), $container);
@@ -43,5 +38,27 @@ class ContainerAwareCallbackSpec extends ObjectBehavior
         $service->dummy($event)->shouldBeCalled()->willReturn(true);
 
         $this->call($event)->shouldReturn(true);
+    }
+
+    function it_calls_invokable_services()
+    {
+        $this->beConstructedWith(array(), array('@my_service'), $container);
+
+        $container->has('my_service')->willReturn(true);
+        $container->get('my_service')->willReturn($service);
+
+        $service->__invoke($event)->shouldBeCalled()->willReturn('I was invoked!');
+
+        $this->call($event)->shouldReturn('I was invoked!');
+    }
+
+    public function __invoke()
+    {
+        return 'I was invoked!';
+    }
+
+    public function dummy()
+    {
+        return true;
     }
 }


### PR DESCRIPTION
I was suprised to find out that callable classes are not supported by the bundle.

This change will check if the service is callable. If it is, set the callback to the service.

If you're happy with this change I can squash the commits.

Before:

``` yaml
order_decrement_coupon_usage:
  on:   ["cancel", "reject"]
  do:   ["@shop.callback.decrement_coupon_usage", "__invoke"]
  args: ["object"]
```

After:

``` yaml
order_decrement_coupon_usage:
  on:   ["cancel", "reject"]
  do:   "@shop.callback.decrement_coupon_usage"
  args: ["object"]
```
